### PR TITLE
Change formatting of initialize command to be code

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@
 
 ## Installation
 
-Install this starter (assuming Gatsby is installed) by running from your CLI: 
+Install this starter (assuming Gatsby is installed) by running from your CLI:
+
 `gatsby new gatsby-starter-ceevee https://github.com/amandeepmittal/gatsby-starter-ceevee`
 
 Run `gatsby develop` in the terminal to start.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@
 
 ## Installation
 
-Install this starter (assuming Gatsby is installed) by running from your CLI: gatsby new gatsby-starter-ceevee https://github.com/amandeepmittal/gatsby-starter-ceevee
+Install this starter (assuming Gatsby is installed) by running from your CLI: 
+`gatsby new gatsby-starter-ceevee https://github.com/amandeepmittal/gatsby-starter-ceevee`
 
 Run `gatsby develop` in the terminal to start.
 


### PR DESCRIPTION
I changed the formatting of the initialize command to be code. I had initially forgot to include the link when creating the new gatsby project